### PR TITLE
docs: fix wrong-org bitsocial-cli link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ bitsocial community edit your-community.bso \
   '--settings.challenges[0].options.transferCooldownSeconds' '604800'
 ```
 
-See the [bitsocial-cli documentation](https://github.com/bitsocial/bitsocial-cli) for full CLI reference.
+See the [bitsocial-cli documentation](https://github.com/bitsocialnet/bitsocial-cli) for full CLI reference.
 
 ## Where MintPass is useful
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -207,7 +207,7 @@ bitsocial community edit your-community.bso \
   '--settings.challenges[0].options.transferCooldownSeconds' '604800'
 ```
 
-See the [bitsocial-cli documentation](https://github.com/bitsocial/bitsocial-cli) for full CLI reference.
+See the [bitsocial-cli documentation](https://github.com/bitsocialnet/bitsocial-cli) for full CLI reference.
 
 ## Where MintPass is useful
 

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -207,7 +207,7 @@ bitsocial community edit your-community.bso \
   '--settings.challenges[0].options.transferCooldownSeconds' '604800'
 ```
 
-See the [bitsocial-cli documentation](https://github.com/bitsocial/bitsocial-cli) for full CLI reference.
+See the [bitsocial-cli documentation](https://github.com/bitsocialnet/bitsocial-cli) for full CLI reference.
 
 ## Where MintPass is useful
 


### PR DESCRIPTION
## What

Fixes a wrong-org link in `README.md`: the "bitsocial-cli documentation" link pointed at `github.com/bitsocial/bitsocial-cli` (the `bitsocial` org has no such repo — 404). Repointed to `bitsocialnet/bitsocial-cli` (verified).

**Scope:** link correction only — no license or content changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL fix with no runtime or security impact.
> 
> **Overview**
> Updates the **bitsocial-cli documentation** link from `github.com/bitsocial/bitsocial-cli` (404) to `github.com/bitsocialnet/bitsocial-cli` in `README.md` and the mirrored LLM context files `llms-full.txt` and `web/public/llms-full.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a34195a2b09bb5416de703dc383f5d255fd90a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference links to point to the current repository location.
  * Aligned embedded documentation snippets with the latest link destination.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->